### PR TITLE
fix: persist appId across app restarts

### DIFF
--- a/src/stores/app.store.ts
+++ b/src/stores/app.store.ts
@@ -13,7 +13,9 @@ const useAppStore = using<AppStore>((setStore) => {
     if (_appId) return _appId;
 
     const appId = crypto.randomUUID();
-    LOCAL_STORAGE.set(LOCAL_STORAGE_KEYS.APP_ID, appId).catch(() => null);
+    LOCAL_STORAGE.set(LOCAL_STORAGE_KEYS.APP_ID, appId)
+      .then(() => LOCAL_STORAGE.save())
+      .catch(() => null);
     setStore((store) => ({ ...store, appId }));
     return appId;
   };


### PR DESCRIPTION
createAppId 中 set() 后未调用 save()，appId 仅写入内存，
依赖 autoSave 100ms 防抖异步刷盘。若 app 在刷盘前被终止，
appId 丢失，下次启动重新生成新的 UUID。

修复：set() 成功后链式调用 save()，确保立即持久化。